### PR TITLE
Update pygrep.conf

### DIFF
--- a/pygrep.conf
+++ b/pygrep.conf
@@ -1,4 +1,4 @@
-BackupID (([a-zA-Z0-9\-\.]+)(\.?(com|org|net|mil|edu|COM|ORG|NET|MIL|EDU)?)?_\d{10})
+BackupID (([a-zA-Z0-9\-\.]+)_(\d{10}))
 Hostname [a-zA-Z]+[0-9\-\.]+\.?(com|org|net|mil|edu|COM|ORG|NET|MIL|EDU)?
 DiskMediaID @[a-z]{5}
 TapeMediaID [A-Za-z0-9]{6}


### PR DESCRIPTION
Changed backup ID to remove empty groupings, now the regex produces three groups, the full backup ID, the client name, and the c-time.